### PR TITLE
chore: bump version to 4.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The hooks redirect reads from the sensor to a staged file on disk. Two files do 
 | Replacement **video** for preview | `/[internal-storage]/DCIM/Camera1/virtual.mp4` | Must match the preview resolution the target app requests (it toasts this on first open). |
 | Replacement **still image** for capture | `/[internal-storage]/DCIM/Camera1/1000.bmp` | Extension is nominal; any BitmapFactory-decodable image renamed to `.bmp` works. |
 
-A small set of empty marker files beside them toggle behaviour: `disable.jpg`, `force_show.jpg`, `no-silent.jpg`, `private_dir.jpg`, `no_toast.jpg`. These are *flag files* — the hook's runtime reads their existence, not their contents. The v4.5 UI writes and deletes them for you; nostalgic users may continue to `touch` them by hand, and nothing will stop them.
+A small set of empty marker files beside them toggle behaviour: `disable.jpg`, `force_show.jpg`, `no-silent.jpg`, `private_dir.jpg`, `no_toast.jpg`. These are *flag files* — the hook's runtime reads their existence, not their contents. The UI writes and deletes them for you; nostalgic users may continue to `touch` them by hand, and nothing will stop them.
 
 ### Architecture, drawn rather than waffled
 
@@ -91,7 +91,7 @@ Observe what is *not* here: no daemon, no content provider, no IPC contract you 
 
 ## 3. What Phase 2 changed
 
-Phase 1 (issue #1) moved the project onto an English-default string catalogue with Chinese mirrors. Phase 2 (this release, `4.5`) is a companion-app overhaul. The hook is untouched.
+Phase 1 (issue #1) moved the project onto an English-default string catalogue with Chinese mirrors. Phase 2 (this release, `4.8`) is a companion-app overhaul. The hook is untouched.
 
 - **Material 3 UI** (`Theme.Material3.DayNight`), dynamic color on Android 12+, `MaterialToolbar` + `CoordinatorLayout` + `MaterialCardView` sections for *Status*, *Source media*, and *Advanced*. `MaterialButton` and `MaterialSwitch` throughout. Light/dark follow the system.
 - **Image/video picker** using `ActivityResultContracts.GetContent` — which, on Android 13+, transparently delegates to the system Photo Picker. No `READ_EXTERNAL_STORAGE` broadside is required on modern Android. The selected URI is streamed into the hook's expected target file; the last-chosen URI is persisted in `SharedPreferences`.

--- a/README_tc.md
+++ b/README_tc.md
@@ -33,7 +33,7 @@ VCAM 是一個典型的 Xposed 模組。在具備可用框架（LSPosed、EdXpos
 | 預覽用**影片** | `/[內部儲存]/DCIM/Camera1/virtual.mp4` | 解析度需符合目標 App 首次開啟時 Toast 顯示的數值。 |
 | 拍照用**靜態圖片** | `/[內部儲存]/DCIM/Camera1/1000.bmp` | 副檔名僅為約定，任何 BitmapFactory 可解碼的圖片改名 `.bmp` 皆可。 |
 
-旁邊還有若干「標記檔」開關：`disable.jpg`、`force_show.jpg`、`no-silent.jpg`、`private_dir.jpg`、`no_toast.jpg`。掛鉤只關心它們**是否存在**，並不讀內容。4.5 版的 UI 會替你建立／刪除；懷舊派繼續用 `touch` 完全合法。
+旁邊還有若干「標記檔」開關：`disable.jpg`、`force_show.jpg`、`no-silent.jpg`、`private_dir.jpg`、`no_toast.jpg`。掛鉤只關心它們**是否存在**，並不讀內容。UI 會替你建立／刪除；懷舊派繼續用 `touch` 完全合法。
 
 ### 與其囉嗦，不如作圖
 
@@ -91,7 +91,7 @@ flowchart LR
 
 ## 3. 第二階段改了什麼
 
-第一階段（issue #1）將專案遷為英文預設、中文鏡像的字串目錄。第二階段（本次 `4.5` 發布）是配套 App 的全面整修。掛鉤本身未動。
+第一階段（issue #1）將專案遷為英文預設、中文鏡像的字串目錄。第二階段（本次 `4.8` 發布）是配套 App 的全面整修。掛鉤本身未動。
 
 - **Material 3 UI**：`Theme.Material3.DayNight`；Android 12+ 啟用動態取色；`MaterialToolbar + CoordinatorLayout + MaterialCardView` 把介面分為「狀態」「來源媒體」「進階」三張卡；全面採用 `MaterialButton` / `MaterialSwitch`；淺色／深色跟隨系統。
 - **圖片／影片選取器**：以 `ActivityResultContracts.GetContent` 為基礎，Android 13+ 會自動走系統 Photo Picker。現代 Android 上不再粗暴索取 `READ_EXTERNAL_STORAGE`。所選 URI 以串流方式寫入掛鉤期望的目標檔；上次選擇的 URI 寫入 `SharedPreferences`。

--- a/README_zh.md
+++ b/README_zh.md
@@ -33,7 +33,7 @@ VCAM 是一个典型的 Xposed 模块。在具备可用框架（LSPosed、EdXpos
 | 预览用**视频** | `/[内部存储]/DCIM/Camera1/virtual.mp4` | 分辨率需匹配目标 App 首次打开时 Toast 提示的数值。 |
 | 拍照用**静态图片** | `/[内部存储]/DCIM/Camera1/1000.bmp` | 扩展名只是约定，任何 BitmapFactory 可解码的图片改名为 `.bmp` 均可。 |
 
-旁边还有若干"标记文件"开关：`disable.jpg`、`force_show.jpg`、`no-silent.jpg`、`private_dir.jpg`、`no_toast.jpg`。挂钩只关心它们**是否存在**，不读内容。4.5 版本的 UI 会替你新建/删除，怀旧派继续用 `touch` 也完全合法。
+旁边还有若干"标记文件"开关：`disable.jpg`、`force_show.jpg`、`no-silent.jpg`、`private_dir.jpg`、`no_toast.jpg`。挂钩只关心它们**是否存在**，不读内容。UI 会替你新建/删除，怀旧派继续用 `touch` 也完全合法。
 
 ### 与其废话，不如作图
 
@@ -91,7 +91,7 @@ flowchart LR
 
 ## 3. 第二阶段改了什么
 
-第一阶段（issue #1）把项目迁到英语为默认、中文为镜像的字符串目录。第二阶段（本次 `4.5` 发布）是对配套 App 的全面翻新。挂钩本身未动。
+第一阶段（issue #1）把项目迁到英语为默认、中文为镜像的字符串目录。第二阶段（本次 `4.8` 发布）是对配套 App 的全面翻新。挂钩本身未动。
 
 - **Material 3 UI**：`Theme.Material3.DayNight`，Android 12+ 开启动态取色，`MaterialToolbar + CoordinatorLayout + MaterialCardView` 把界面划为「状态」「素材媒体」「高级」三张卡；全面替换为 `MaterialButton` / `MaterialSwitch`；浅色/深色跟随系统。
 - **图片/视频选择器**：基于 `ActivityResultContracts.GetContent`，Android 13+ 自动走系统 Photo Picker。现代 Android 上不再一刀切地索取 `READ_EXTERNAL_STORAGE`。选中的 URI 通过流拷贝写入挂钩期望的目标文件；上一次选择的 URI 持久化到 `SharedPreferences`。

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "com.example.vcam"
         minSdk 21
         targetSdk 34
-        versionCode 30
-        versionName "4.7"
+        versionCode 31
+        versionName "4.8"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
Agent-Logs-Url: https://github.com/Steake/com.example.vcam/sessions/d6f83313-42ca-40ea-aa94-4cd3f6edcee8